### PR TITLE
Separate MXBoard loggers from Python root logger

### DIFF
--- a/python/mxboard/event_file_writer.py
+++ b/python/mxboard/event_file_writer.py
@@ -37,6 +37,7 @@ class EventsWriter(object):
     """Writes `Event` protocol buffers to an event file. This class is ported from
     EventsWriter defined in
     https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/util/events_writer.cc"""
+
     def __init__(self, file_prefix, verbose=True):
         """
         Events files have a name of the form
@@ -58,7 +59,7 @@ class EventsWriter(object):
     def _init_if_needed(self):
         if self._recordio_writer is not None:
             return
-        self._filename = self._file_prefix + ".out.tfevents." + str(time.time())[:10] \
+        self._filename = self._file_prefix + ".out.tfevents." + str(time.time())[:10]\
                          + "." + socket.gethostname() + self._file_suffix
         self._recordio_writer = RecordWriter(self._filename)
         if self._logger is not None:

--- a/python/mxboard/event_file_writer.py
+++ b/python/mxboard/event_file_writer.py
@@ -37,7 +37,6 @@ class EventsWriter(object):
     """Writes `Event` protocol buffers to an event file. This class is ported from
     EventsWriter defined in
     https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/util/events_writer.cc"""
-
     def __init__(self, file_prefix, verbose=True):
         """
         Events files have a name of the form

--- a/python/mxboard/writer.py
+++ b/python/mxboard/writer.py
@@ -226,7 +226,10 @@ class SummaryWriter(object):
         self._file_writer = FileWriter(logdir=logdir, max_queue=max_queue,
                                        flush_secs=flush_secs, filename_suffix=filename_suffix,
                                        verbose=verbose)
-        self._verbose = verbose
+        self._logger = None
+        if verbose:
+            self._logger = logging.getLogger(__name__)
+            self._logger.setLevel(logging.INFO)
         self._default_bins = None
         self._text_tags = []
 
@@ -428,8 +431,8 @@ class SummaryWriter(object):
                 raise ValueError('expected equal values of embedding first dim and length of '
                                  'labels, while received %d and %d for each'
                                  % (embedding_shape[0], len(labels)))
-            if self._verbose:
-                logging.info('saving embedding labels to %s', save_path)
+            if self._logger is not None:
+                self._logger.info('saving embedding labels to %s', save_path)
             _make_metadata_tsv(labels, save_path)
         if images is not None:
             img_labels_shape = images.shape
@@ -437,11 +440,11 @@ class SummaryWriter(object):
                 raise ValueError('expected equal first dim size of embedding and images,'
                                  ' while received %d and %d for each' % (embedding_shape[0],
                                                                          img_labels_shape[0]))
-            if self._verbose:
-                logging.info('saving embedding images to %s', save_path)
+            if self._logger is not None:
+                self._logger.info('saving embedding images to %s', save_path)
             _make_sprite_image(images, save_path)
-        if self._verbose:
-            logging.info('saving embedding data to %s', save_path)
+        if self._logger is not None:
+            self._logger.info('saving embedding data to %s', save_path)
         _save_embedding_tsv(embedding, save_path)
         _add_embedding_config(self.get_logdir(), data_dir, labels is not None,
                               images.shape if images is not None else None)

--- a/python/mxboard/writer.py
+++ b/python/mxboard/writer.py
@@ -432,7 +432,7 @@ class SummaryWriter(object):
                                  'labels, while received %d and %d for each'
                                  % (embedding_shape[0], len(labels)))
             if self._logger is not None:
-                self._logger.info('saving embedding labels to %s', save_path)
+                self._logger.info('saved embedding labels to %s', save_path)
             _make_metadata_tsv(labels, save_path)
         if images is not None:
             img_labels_shape = images.shape
@@ -441,10 +441,10 @@ class SummaryWriter(object):
                                  ' while received %d and %d for each' % (embedding_shape[0],
                                                                          img_labels_shape[0]))
             if self._logger is not None:
-                self._logger.info('saving embedding images to %s', save_path)
+                self._logger.info('saved embedding images to %s', save_path)
             _make_sprite_image(images, save_path)
         if self._logger is not None:
-            self._logger.info('saving embedding data to %s', save_path)
+            self._logger.info('saved embedding data to %s', save_path)
         _save_embedding_tsv(embedding, save_path)
         _add_embedding_config(self.get_logdir(), data_dir, labels is not None,
                               images.shape if images is not None else None)


### PR DESCRIPTION
*Description of changes:*
Separate mxboard logger from the root logger. The mxboard logger is toggled by the `verbose` parameter in the initializer of `SummaryWriter`. When `verbose=True`, two loggers are created with `level=INFO` for `SummaryWriter` and `EventsWriter`, respectively.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
