### PR TITLE
Improve logging images

### DIFF
--- a/python/mxboard/writer.py
+++ b/python/mxboard/writer.py
@@ -313,7 +313,7 @@ class SummaryWriter(object):
         and image will be replicated three times and concatenated along the channel axis.
         If the input image is 3D, it will be replicated three times and concatenated along
         the channel axis. If the input image is 4D, which is a batch images, all the
-        images will be spliced as a big square image for display.
+        images will be spliced as a sprite image for display.
 
         Note: This function requires the ``pillow`` package.
 
@@ -328,15 +328,12 @@ class SummaryWriter(object):
                 Name for the `image`.
             image : MXNet `NDArray` or `numpy.ndarray`
                 Image is one of the following formats: (H, W), (C, H, W), (N, C, H, W).
-                For float image data types, the values are normalized one image at a time to fit
-                in the range `[0, 255]`. 'uint8` values are unchanged. The following two
-                normalization algorithms are used for different conditions:
-                1. If the input values are all positive, they are rescaled so that the largest one
-                is 255.
-                2. If any input value is negative, the values are shifted so that the input value
-                0.0 is at 127.
-                They are then rescaled so that either the smallest value is 0, or the largest
-                one is 255.
+                If the input is a batch of images, a grid of images is made by stitching them
+                together.
+                If data type is float, values must be in range [0, 1], and then they are
+                rescaled to range [0, 255]. Note that this does not change the values of the
+                input `image`. A copy of the input `image` is created instead.
+                If data type is 'uint8`, values are unchanged.
             global_step : int
                 Global step value to record.
         """

--- a/tests/python/unittest/test_logging.py
+++ b/tests/python/unittest/test_logging.py
@@ -212,7 +212,7 @@ def test_make_sprite_image():
                 shape_list[0] = 3
             elif ndim == 4:
                 shape_list[1] = 3
-            data = rand_ndarray(tuple(shape_list), 'default', dtype=dtype)
+            data = rand_ndarray(tuple(shape_list), 'default', dtype=dtype).clip(0, 1)
             make_logdir()
             _make_sprite_image(data, _LOGDIR)
             file_path = os.path.join(_LOGDIR, _SPRITE_PNG)
@@ -292,12 +292,11 @@ def test_add_image():
     shape = list(rand_shape_nd(4))
     shape[1] = 3
     shape = tuple(shape)
-    data = mx.nd.random.normal(shape=shape)
+    data = mx.nd.random.normal(shape=shape).clip(0, 1)
     check_add_image(data)
     check_add_image(data.asnumpy())
-    check_add_image(data.astype('uint8'))
-    check_add_image(data.astype('float16'))
     check_add_image(data.astype('float64'))
+    check_add_image((data * 255).astype('uint8'))
 
 
 @remove_logdir()


### PR DESCRIPTION
*Description of changes:*
Changed images value range to [0, 1] for float types. It's ambiguous to support image values outside this range. Users can rescale the images to uint8 type by themselves before calling `add_image()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
