### PR TITLE
add support for multi labels for embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 .idea
+.vscode
 python/mxboard/proto/[a-z]*.py*
 python/build
 python/dist

--- a/python/mxboard/writer.py
+++ b/python/mxboard/writer.py
@@ -32,6 +32,7 @@ from .summary import scalar_summary, histogram_summary, image_summary, audio_sum
 from .summary import text_summary, pr_curve_summary, _net2pb
 from .utils import _save_embedding_tsv, _make_sprite_image, _make_metadata_tsv
 from .utils import _add_embedding_config, _make_numpy_array, _get_embedding_dir
+from .utils import _is_2D_matrix
 
 
 class SummaryToEventTransformer(object):
@@ -501,7 +502,8 @@ class SummaryWriter(object):
             embedding : MXNet `NDArray` or  `numpy.ndarray`
                 A matrix whose each row is the feature vector of a data point.
             labels : MXNet `NDArray` or `numpy.ndarray` or a list of elements convertible to str.
-                Labels corresponding to the data points in the `embedding`.
+                Labels corresponding to the data points in the `embedding`. If the labels are 2D
+                the first row is considered the column names.
             images : MXNet `NDArray` or `numpy.ndarray`
                 Images of format NCHW corresponding to the data points in the `embedding`.
             global_step : int
@@ -519,9 +521,11 @@ class SummaryWriter(object):
             logging.warning('embedding dir %s exists, files under this dir will be overwritten',
                             save_path)
         if labels is not None:
-            if embedding_shape[0] != len(labels):
+            if (embedding_shape[0] != len(labels) and
+                    (not _is_2D_matrix(labels) or len(labels) != embedding_shape[0] + 1)):
                 raise ValueError('expected equal values of embedding first dim and length of '
-                                 'labels, while received %d and %d for each'
+                                 'labels or embedding first dim + 1 for 2d labels '
+                                 ', while received %d and %d for each'
                                  % (embedding_shape[0], len(labels)))
             if self._logger is not None:
                 self._logger.info('saved embedding labels to %s', save_path)

--- a/tests/python/unittest/test_logging.py
+++ b/tests/python/unittest/test_logging.py
@@ -123,14 +123,29 @@ def logdir_empty():
 
 
 @with_seed()
-def test_make_metadata_tsv():
+def test_make_1D_metadata_tsv():
     make_logdir()
-    shape = rand_shape_nd(num_dim=4, dim=10)
+    shape = rand_shape_nd(num_dim=1, dim=10)
     data = rand_ndarray(shape=shape, stype='default')
     _make_metadata_tsv(data, _LOGDIR)
     file_path = os.path.join(_LOGDIR, 'metadata.tsv')
     data_loaded = np.loadtxt(file_path, dtype=data.dtype)
-    assert_almost_equal(data.asnumpy(), data_loaded.reshape(data.shape), rtol=0.001, atol=0.001)
+    assert_almost_equal(data.asnumpy(), data_loaded.reshape(
+        data.shape), rtol=0.001, atol=0.001)
+    safe_remove_file(file_path)
+    safe_remove_logdir()
+
+
+@with_seed()
+def test_make_2D_metadata_tsv():
+    make_logdir()
+    shape = rand_shape_nd(num_dim=2, dim=10)
+    data = rand_ndarray(shape=shape, stype='default')
+    _make_metadata_tsv(data, _LOGDIR)
+    file_path = os.path.join(_LOGDIR, 'metadata.tsv')
+    data_loaded = np.loadtxt(file_path, dtype=data.dtype)
+    assert_almost_equal(data.asnumpy(), data_loaded.reshape(
+        data.shape), rtol=0.001, atol=0.001)
     safe_remove_file(file_path)
     safe_remove_logdir()
 
@@ -500,11 +515,11 @@ def test_add_graph_gluon():
                       NodeDef(name='hybridsequential0_dense0_fwd/hybridsequential0_dense0_weight', op='null',
                               attr={'param': AttrValue(
                                   s='{ __dtype__ :  0 ,  __lr_mult__ :  1.0 ,  __shape__ :  '
-                                    '(128, 0) ,  __wd_mult__ :  1.0 }'.encode(encoding='utf-8'))}),
+                                    '(128, 0) ,  __storage_type__ :  0 ,  __wd_mult__ :  1.0 }'.encode(encoding='utf-8'))}),
                       NodeDef(name='hybridsequential0_dense0_fwd/hybridsequential0_dense0_bias', op='null',
                               attr={'param': AttrValue(
                                   s='{ __dtype__ :  0 ,  __init__ :  zeros ,  __lr_mult__ :  1.0 ,  __shape__ :  '
-                                    '(128,) ,  __wd_mult__ :  1.0 }'.encode(encoding='utf-8'))}),
+                                    '(128,) ,  __storage_type__ :  0 ,  __wd_mult__ :  1.0 }'.encode(encoding='utf-8'))}),
                       NodeDef(name='hybridsequential0_dense0_fwd/hybridsequential0_dense0_fwd', op='FullyConnected',
                               input=['data', 'hybridsequential0_dense0_fwd/hybridsequential0_dense0_weight',
                                      'hybridsequential0_dense0_fwd/hybridsequential0_dense0_bias'],


### PR DESCRIPTION
This pr adds support for multi labels per data point for the tensorboard embeddings. 
This means you can now pass a either a 1D or 2D list/numpy.ndarray/mx.ndarray for the labels to the `add_embedding` for use in tensorboard. 
The file format for the 2D label input is a TSV with column headers based on the tensorboard documentation https://www.tensorflow.org/guide/embedding#metadata

I tired to cover my bases with the input checking, any suggestions for improvements are appreciated. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
