### PR TITLE
fix text_summary for newer version of tensorboard

### DIFF
--- a/python/mxboard/summary.py
+++ b/python/mxboard/summary.py
@@ -266,7 +266,7 @@ def text_summary(tag, text):
     tensor = TensorProto(dtype='DT_STRING',
                          string_val=[text.encode(encoding='utf_8')],
                          tensor_shape=TensorShapeProto(dim=[TensorShapeProto.Dim(size=1)]))
-    return Summary(value=[Summary.Value(node_name=tag, metadata=smd, tensor=tensor)])
+    return Summary(value=[Summary.Value(tag=tag, metadata=smd, tensor=tensor)])
 
 
 def pr_curve_summary(tag, labels, predictions, num_thresholds, weights=None):


### PR DESCRIPTION
*Issue #, if available:*
24

*Description of changes:*
Comparing with tensorboardX, the parameter keyboard should be "tag" instead of "node_name".
Refer to https://github.com/lanpa/tensorboardX/blob/master/tensorboardX/summary.py#L385

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
