### PR TITLE
Change README: tensorboard no longer requires tensorflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To visualize those data in browsers, users still have to install
 separately.
 
 ```bash
-pip install tensorflow tensorboard
+pip install tensorboard
 ```
 
 Use the following to verify that the TensorBoard binary has been installed correctly.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Tensorboard no longer requires TensorFlow, so remove `tensorflow` from the installation instruction for `tensorboard`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@reminisce 