### PR TITLE
Rename proto package name to avoid conflicts between tensorboard.

### DIFF
--- a/python/mxboard/proto/attr_value.proto
+++ b/python/mxboard/proto/attr_value.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorboard;
+package mxboard;
 option cc_enable_arenas = true;
 option java_outer_classname = "AttrValueProtos";
 option java_multiple_files = true;

--- a/python/mxboard/proto/event.proto
+++ b/python/mxboard/proto/event.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorboard;
+package mxboard;
 option cc_enable_arenas = true;
 option java_outer_classname = "EventProtos";
 option java_multiple_files = true;

--- a/python/mxboard/proto/graph.proto
+++ b/python/mxboard/proto/graph.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorboard;
+package mxboard;
 option cc_enable_arenas = true;
 option java_outer_classname = "GraphProtos";
 option java_multiple_files = true;

--- a/python/mxboard/proto/node_def.proto
+++ b/python/mxboard/proto/node_def.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorboard;
+package mxboard;
 option cc_enable_arenas = true;
 option java_outer_classname = "NodeProto";
 option java_multiple_files = true;

--- a/python/mxboard/proto/plugin_pr_curve.proto
+++ b/python/mxboard/proto/plugin_pr_curve.proto
@@ -15,7 +15,7 @@ limitations under the License.
 
 syntax = "proto3";
 
-package tensorboard;
+package mxboard;
 
 message PrCurvePluginData {
   // Version `0` is the only supported version.

--- a/python/mxboard/proto/resource_handle.proto
+++ b/python/mxboard/proto/resource_handle.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorboard;
+package mxboard;
 option cc_enable_arenas = true;
 option java_outer_classname = "ResourceHandle";
 option java_multiple_files = true;

--- a/python/mxboard/proto/summary.proto
+++ b/python/mxboard/proto/summary.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorboard;
+package mxboard;
 option cc_enable_arenas = true;
 option java_outer_classname = "SummaryProtos";
 option java_multiple_files = true;

--- a/python/mxboard/proto/tensor.proto
+++ b/python/mxboard/proto/tensor.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorboard;
+package mxboard;
 option cc_enable_arenas = true;
 option java_outer_classname = "TensorProtos";
 option java_multiple_files = true;

--- a/python/mxboard/proto/tensor_shape.proto
+++ b/python/mxboard/proto/tensor_shape.proto
@@ -6,7 +6,7 @@ option java_outer_classname = "TensorShapeProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
 
-package tensorboard;
+package mxboard;
 
 // Dimensions of a tensor.
 message TensorShapeProto {

--- a/python/mxboard/proto/types.proto
+++ b/python/mxboard/proto/types.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorboard;
+package mxboard;
 option cc_enable_arenas = true;
 option java_outer_classname = "TypesProtos";
 option java_multiple_files = true;

--- a/python/mxboard/proto/versions.proto
+++ b/python/mxboard/proto/versions.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorboard;
+package mxboard;
 option cc_enable_arenas = true;
 option java_outer_classname = "VersionsProtos";
 option java_multiple_files = true;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR renames the package in protobuf definitions. Sometimes we need to import tensorboard/tensorflow when using mxboard in mxnet, but the proto package from tensorboard was registered in mxboard already, and protobuf library will throw `TypeError`. Rename the package in mxboard will solve this issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
