### PR TITLE
Support summary written to HDFS

### DIFF
--- a/python/mxboard/__init__.py
+++ b/python/mxboard/__init__.py
@@ -20,4 +20,4 @@
 from __future__ import absolute_import
 from .writer import SummaryWriter
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/python/mxboard/event_file_writer.py
+++ b/python/mxboard/event_file_writer.py
@@ -130,8 +130,15 @@ class EventFileWriter(object):
         the event file:
         """
         self._logdir = logdir
-        if not os.path.exists(self._logdir):
-            os.makedirs(self._logdir)
+        parse_result = six.moves.urllib.parse.urlparse(self._logdir)
+        if parse_result.scheme == '':
+            if not os.path.exists(self._logdir):
+                os.makedirs(self._logdir)
+        elif parse_result.scheme in ('hdfs', 'viewfs'):
+            import pyarrow.fs
+            hdfs = pyarrow.fs.HadoopFileSystem(host='default', port=0)
+            hdfs.create_dir(parse_result.path)
+
         self._event_queue = six.moves.queue.Queue(max_queue)
         self._ev_writer = EventsWriter(os.path.join(self._logdir, "events"), verbose=verbose)
         self._flush_secs = flush_secs

--- a/python/setup.py
+++ b/python/setup.py
@@ -50,7 +50,7 @@ if compile_summary_protobuf() != 0:
 
 setup(
     name='mxboard',
-    version='0.1.0',
+    version='0.1.1',
     description='A logging tool for visualizing MXNet data in TensorBoard',
     long_description='MXBoard is a logging tool that enables visualization of MXNet data in TensorBoard.',
     author='Amazon Web Services',


### PR DESCRIPTION
This PR supports use case below:
```python
from mxboard import SummaryWriter
with SummaryWriter(logdir='hdfs://hdfs-nn-proxy-ns1/department/ai/user/xyz/logs') as sw:
    for i in range(10):
        # create a normal distribution with fixed mean and decreasing std
        data = mx.nd.normal(loc=0, scale=10.0/(i+1), shape=(10, 3, 8, 8))
        sw.add_histogram(tag='norml_dist', values=data, bins=200, global_step=i)
```